### PR TITLE
Rebrand upload links to Windup

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,7 +27,7 @@ module.exports = {
       },
     ],
     windup: {
-      version: "5.3.0.Final",
+      version: "6.0.0.Final",
       idePlugins: [
         {
           title: "IntelliJ (Tech preview)",

--- a/src/content/blog/getting-started/index.md
+++ b/src/content/blog/getting-started/index.md
@@ -8,7 +8,7 @@ tags:
   - docs
 ---
 
-There are 2 distributions available within the first upstream release; the [CLI](#installing-the-cli) and the [Web UI](#installing-the-web-ui).
+There are 2 distributions available within the first upstream release; the [CLI](#installing-the-cli) and the [Web UI](#installing-the-web-ui-locally).
 
 ## Prerequisites
 

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -9,14 +9,14 @@ const AboutPage = ({ data }) => {
     {
       title: "CLI",
       description: "Command Line Interface",
-      url: `https://repo1.maven.org/maven2/org/jboss/windup/mta-cli/${windupVersion}/mta-cli-${windupVersion}-offline.zip`,
-      sha1: `https://repo1.maven.org/maven2/org/jboss/windup/mta-cli/${windupVersion}/mta-cli-${windupVersion}-offline.zip.sha1`,
+      url: `https://repo1.maven.org/maven2/org/jboss/windup/windup-cli/${windupVersion}/windup-cli-${windupVersion}-offline.zip`,
+      sha1: `https://repo1.maven.org/maven2/org/jboss/windup/windup-cli/${windupVersion}/windup-cli-${windupVersion}-offline.zip.sha1`,
     },
     {
       title: "Web Console",
       description: "Web UI for local installation and Openshift deployment",
-      url: `https://repo1.maven.org/maven2/org/jboss/windup/web/mta-web-distribution/${windupVersion}/mta-web-distribution-${windupVersion}-with-authentication.zip`,
-      sha1: `https://repo1.maven.org/maven2/org/jboss/windup/web/mta-web-distribution/${windupVersion}/mta-web-distribution-${windupVersion}-with-authentication.zip.sha1`,
+      url: `https://repo1.maven.org/maven2/org/jboss/windup/web/windup-web-distribution/${windupVersion}/windup-web-distribution-${windupVersion}-with-authentication.zip`,
+      sha1: `https://repo1.maven.org/maven2/org/jboss/windup/web/windup-web-distribution/${windupVersion}/windup-web-distribution-${windupVersion}-with-authentication.zip.sha1`,
     },
   ];
   const quickstart = `https://github.com/windup/windup-quickstarts/tree/${windupVersion}`;


### PR DESCRIPTION
- Updated last version of Windup to 6.0.0.Final
- Fix the download links since they were pointing to MTA, now that we have Windup we must point to WIndup artifacts
- Fixed a link in the getting-started blog